### PR TITLE
small factor to character conversion error with getResults()

### DIFF
--- a/R/getResults.R
+++ b/R/getResults.R
@@ -53,7 +53,7 @@ getResults <- function(output="./", save_to_file=TRUE) {
 
 		for (i in seq_along(1:nrow(finished_list))) 
 		{
-			curl_download(finished_list$resultUrl[i], destfile=paste0(output, finished_list$id[i]))
+			curl_download(as.character(finished_list$resultUrl[i]), destfile=paste0(output, finished_list$id[i]))
 			finished_list$local_file_path[i] <- paste0(output, finished_list$id[i])
 			pb$tick()
 		}


### PR DESCRIPTION
Hi --

I am using your abbyyR package, which I much appreciate. I have encountered an error using getResults(), it appears that there is an error where curlDownload is being used with a factor variable. All that I did was add an as.character conversion and the function works fine now. Let me know if you have any questions. That was the only change I made to the code.

Regards,

Robert Kubinec